### PR TITLE
remove gasstation hard dep as it works with other mixin mods otherwise.

### DIFF
--- a/src/main/java/com/github/basdxz/rightproperguiscale/Tags.java
+++ b/src/main/java/com/github/basdxz/rightproperguiscale/Tags.java
@@ -14,8 +14,7 @@ public final class Tags {
     public static final String GROUPNAME = "GRADLETOKEN_GROUPNAME";
 
     public static final String MINECRAFT_VERSION = "[1.7.10]";
-    public static final String DEPENDENCIES = "required-after:gasstation@[0.5.1,);" +
-                                              "required-after:falsepatternlib@[0.10.13,);";
+    public static final String DEPENDENCIES = "required-after:falsepatternlib@[0.10.13,);";
     public static final String GUI_FACTORY_PATH = GROUPNAME + ".config.RightProperGUIScaleGuiFactory";
     public static final String PROXY_PATH = GROUPNAME + ".proxy";
     public static final String CLIENT_PROXY_PATH = PROXY_PATH + ".ClientProxy";

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -14,7 +14,6 @@
         "logoFile": "logo.png",
         "screenshots": [],
         "dependencies": [
-            "required-after:gasstation@[0.5.1,)",
             "required-after:falsepatternlib@[0.10.13,)"
         ]
     }


### PR DESCRIPTION
the gasstation dependency here is not actually necessary, it just needs mixins to be loaded that are compatible with it and FPL, this specifically makes it incompatible with the modular release of [UniMixins](https://github.com/LegacyModdingMC/UniMixins) without the gasstation module, despite the mod using 0 gasstation specific features, nor does it subdeps.