### PR TITLE
Draft: Fix BQ 2 compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1656003793falsepattern74
+//version: 1656003793falsepattern76
 /*
 DO NOT CHANGE THIS FILE!
 
@@ -311,7 +311,11 @@ configurations {
 repositories {
     maven {
         name = "Overmind forge repo mirror"
-        url = "https://gregtech.overminddl1.com/"
+        url = "https://mvn.falsepattern.com/overmind"
+        content {
+            includeGroup("net.minecraftforge")
+            includeGroup("org.scala-lang")
+        }
     }
     if(usesMixins.toBoolean() || hasMixinDeps.toBoolean()) {
         maven {
@@ -1032,6 +1036,10 @@ static unzip(String zipFileName, String outputDir) {
 configure(deobfParams) {
     group = 'forgegradle'
     description = 'Rename all obfuscated parameter names inherited from Minecraft classes'
+}
+
+tasks.withType(JavaCompile) {
+    options.encoding = 'UTF-8'
 }
 
 // Dependency Deobfuscation

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -20,5 +20,7 @@ dependencies {
     implementation("com.falsepattern:falsepatternlib-mc1.7.10:0.11.2:dev")
 
     // Better Questing 3.0.328
-    implementation(deobfCurse("better-questing-238856:2950244"))
+    implementation(deobfCurse("better-questing-3-238856:2950244"))
+    // Better Questing 2.0.233
+    implementation(deobfCurse("better-questing-2-238856:2433316"))
 }

--- a/src/main/java/com/github/basdxz/rightproperguiscale/mixin/mixins/client/betterquesting/RenderUtilsScissorAlignment2Mixin.java
+++ b/src/main/java/com/github/basdxz/rightproperguiscale/mixin/mixins/client/betterquesting/RenderUtilsScissorAlignment2Mixin.java
@@ -1,0 +1,74 @@
+package com.github.basdxz.rightproperguiscale.mixin.mixins.client.betterquesting;
+
+import betterquesting.api.utils.RenderUtils;
+import betterquesting.api2.client.gui.misc.GuiRectangle;
+import com.github.basdxz.rightproperguiscale.mixin.interfaces.client.minecraft.IScaledResolutionMixin;
+import lombok.val;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.ScaledResolution;
+import org.lwjgl.opengl.GL11;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+/**
+ * A Mixin for {@link RenderUtils} to fix the offset and scale in {@link RenderUtils#startScissor}.
+ * <p>
+ * The warnings are supressed as the Minecraft Development plugin for Intellij IDEA fails to recongise the entry points.
+ */
+@SuppressWarnings("ALL")
+@Mixin(value = RenderUtils.class, remap = false)
+public abstract class RenderUtilsScissorAlignment2Mixin {
+    /**
+     * Injects right before the scissor is started, captures the variables in scope.
+     * Then creates and caches a new {@link GuiRectangle} with the correct scale and offset.
+     *
+     * @param ci   mixin callback info
+     * @param mc   minecraft instance
+     * @param r    scaled resolution
+     * @param f    original gui scale
+     * @param x    pos x to scissor
+     * @param y    pos y to scissor
+     * @param w    width to scissor
+     * @param h    height to scissor
+     */
+    @Inject(method = "guiScissor",
+            at = @At(value = "INVOKE", target = "Lorg/lwjgl/opengl/GL11;glScissor(IIII)V"),
+            locals = LocalCapture.CAPTURE_FAILHARD,
+            require = 1, cancellable = true)
+    private static void glScissor(Minecraft mc,
+                                  int x,
+                                  int y,
+                                  int w,
+                                  int h,
+                                  CallbackInfo ci,
+                                  ScaledResolution r,
+                                  int f) {
+        val scaledResolution = (IScaledResolutionMixin) r;
+        val scale = scaledResolution.scaleFactor();
+        val scaledHeight = (float) scaledResolution.scaledHeight();
+
+        // Does not change the behavior of the original code, simply makes it scale with the float scale factor.
+        val posX = safeRound(x * scale);
+        val posY = safeRound((scaledHeight - y - h) * scale);
+        val width = safeRound(w * scale);
+        val height = safeRound(h * scale);
+
+        GL11.glScissor(posX, posY, width, height);
+        ci.cancel();
+    }
+
+    /**
+     * Rounds a float to the nearest integer, clamping it to be more than or equal to one.
+     * <p>
+     * Important as otherwise GUI elements may have a scale of zero, which causes problems.
+     *
+     * @param value the value to round
+     * @return the rounded value clamped to >= 1
+     */
+    private static int safeRound(float value) {
+        return Math.max(Math.round(value), 1);
+    }
+}

--- a/src/main/java/com/github/basdxz/rightproperguiscale/mixin/mixins/client/betterquesting/RenderUtilsScissorAlignment3Mixin.java
+++ b/src/main/java/com/github/basdxz/rightproperguiscale/mixin/mixins/client/betterquesting/RenderUtilsScissorAlignment3Mixin.java
@@ -21,7 +21,7 @@ import java.nio.FloatBuffer;
  */
 @SuppressWarnings("ALL")
 @Mixin(value = RenderUtils.class, remap = false)
-public abstract class RenderUtilsScissorAlignmentMixin {
+public abstract class RenderUtilsScissorAlignment3Mixin {
     /**
      * A cached rectangle, created when the local variables are captured and used when the rectangle would be created.
      */

--- a/src/main/java/com/github/basdxz/rightproperguiscale/mixin/plugin/Mixin.java
+++ b/src/main/java/com/github/basdxz/rightproperguiscale/mixin/plugin/Mixin.java
@@ -48,7 +48,8 @@ public enum Mixin implements IMixin {
     /**
      * Better Questing specific Mixins.
      */
-    RenderUtilsScissorAlignmentMixin(CLIENT, require(BETTER_QUESTING), "betterquesting.RenderUtilsScissorAlignmentMixin"),
+    //RenderUtilsScissorAlignment3Mixin(CLIENT, require(BETTER_QUESTING_3), "betterquesting.RenderUtilsScissorAlignment3Mixin"),
+    RenderUtilsScissorAlignment2Mixin(CLIENT, require(BETTER_QUESTING_2), "betterquesting.RenderUtilsScissorAlignment2Mixin"),
     ;
 
     private final Side side;

--- a/src/main/java/com/github/basdxz/rightproperguiscale/mixin/plugin/TargetedMod.java
+++ b/src/main/java/com/github/basdxz/rightproperguiscale/mixin/plugin/TargetedMod.java
@@ -13,12 +13,14 @@ import static com.falsepattern.lib.mixin.ITargetedMod.PredicateHelpers.startsWit
 @Getter
 @RequiredArgsConstructor
 public enum TargetedMod implements ITargetedMod {
-    OPTIFINE("OptiFine", false, startsWith("optifine")),
-    BETTER_LOADING_SCREEN("BetterLoadingScreen", false, startsWith("betterloadingscreen")),
-    BETTER_QUESTING("BetterQuesting", true, startsWith("betterquesting")),
+    OPTIFINE("OptiFine", false, startsWith("optifine"), null),
+    BETTER_LOADING_SCREEN("BetterLoadingScreen", false, startsWith("betterloadingscreen"), null),
+    BETTER_QUESTING_2("BetterQuesting", true, startsWith("betterquesting"), startsWith("3")),
+    BETTER_QUESTING_3("BetterQuesting", true, startsWith("betterquesting"), startsWith("2")),
     ;
 
     private final String modName;
     private final boolean loadInDevelopment;
     private final Predicate<String> condition;
+    private final Predicate<String> version;
 }


### PR DESCRIPTION
Marking this as a draft for now, because I have no idea how to make the mixin only load when BetterQuesting is on version 2.x, not 3.x.
For testing purposes, I have disabled loading the current BQ 3 mixin - and it works fine!

Fixes #7 